### PR TITLE
bugfix: npm install -g | removed -g

### DIFF
--- a/FunctionAppSvelteTemplate/pre-build.ps1
+++ b/FunctionAppSvelteTemplate/pre-build.ps1
@@ -9,7 +9,7 @@ $appsettingsFileContent = Get-Content -Path $appsettingsFilePath
 $appsettingsFileContent = $appsettingsFileContent -replace '"builts*:\s*false', '"built": true'
 Set-Content -Path $appsettingsFilePath -Value $appsettingsFileContent
 
-npm i -g | Out-Null
+npm i | Out-Null
 npm run build | Out-Null
 
 $appsettingsFileContent = $appsettingsFileContent -replace '"builts*:\s*true', '"built": false'


### PR DESCRIPTION
The "-g" caused issues if you never installed Vite before. Not 100% sure as to why, but this fixes the issue.